### PR TITLE
feat: add lessons to Learn page on user dashboard

### DIFF
--- a/src/app/api/lessons/route.ts
+++ b/src/app/api/lessons/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+// Validate environment variables
+const backendUrl = process.env.BACKEND_API_URL;
+if (!backendUrl)
+  throw new Error('Missing environment variable: BACKEND_API_URL');
+
+export async function GET() {
+  const apiUrl = `${backendUrl}/api/lessons/summary`;
+
+  try {
+    const res = await fetch(apiUrl);
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: 'Backend returned error', details: data },
+        { status: res.status },
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('Lessons proxy error:', err);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/learn/page.tsx
+++ b/src/app/dashboard/learn/page.tsx
@@ -1,5 +1,74 @@
-import React from 'react';
+'use client';
+
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchLessons } from '@/lib/api/lesson';
+import { capitilizeFirstLetter } from '@/lib/utils';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+function LessonCardSkeleton() {
+  return (
+    <Card className="flex flex-col justify-between">
+      <CardHeader>
+        <Skeleton className="h-4 w-16 mb-2" />
+        <Skeleton className="h-5 w-20" />
+      </CardHeader>
+      <CardFooter>
+        <Skeleton className="h-9 w-20" />
+      </CardFooter>
+    </Card>
+  );
+}
 
 export default function DashboardLearn() {
-  return <div>page</div>;
+  const {
+    data: lessons,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['lessons'],
+    queryFn: fetchLessons,
+  });
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground">
+        Failed to load lessons. Please try again.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 w-full max-w-4xl">
+      <h1 className="text-2xl font-bold mb-6">Lessons</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {isLoading
+          ? Array.from({ length: 6 }).map((_, i) => (
+              <LessonCardSkeleton key={i} />
+            ))
+          : lessons?.map((lesson, index) => (
+              <Card key={lesson.uuid} className="flex flex-col justify-between">
+                <CardHeader>
+                  <CardDescription>Lesson {index + 1}</CardDescription>
+                  <CardTitle>{capitilizeFirstLetter(lesson.title)}</CardTitle>
+                </CardHeader>
+                <CardFooter>
+                  <Button asChild>
+                    <Link href={`/lesson/${lesson.uuid}`}>Start</Link>
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+      </div>
+    </div>
+  );
 }

--- a/src/app/lesson/[lessonUuid]/page.tsx
+++ b/src/app/lesson/[lessonUuid]/page.tsx
@@ -16,6 +16,7 @@ import { useSoundEffects } from '@/hooks/useSoundEffects';
 import LessonLoader from '@/components/lesson/LessonLoader';
 
 import { fetchLesson } from '@/lib/api/lesson';
+import { createClient } from '@/utils/supabase/client';
 
 export default function LessonPage() {
   const { lessonUuid } = useParams();
@@ -37,6 +38,15 @@ export default function LessonPage() {
   } = useLessonEngine();
 
   const [lessonItemIndex, setLessonItemIndex] = useState(0);
+
+  // Authentication state just for showing different UI on lesson finish page
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setIsAuthenticated(!!session);
+    });
+  }, []);
 
   // Fetching lesson from database
   const {
@@ -125,6 +135,7 @@ export default function LessonPage() {
           rightAnswered={rightAnswered}
           items={lesson?.items}
           onFinishLesson={finishLesson}
+          isAuthenticated={isAuthenticated}
         />
       </motion.div>
     );

--- a/src/components/lesson/LessonFinish.tsx
+++ b/src/components/lesson/LessonFinish.tsx
@@ -13,19 +13,21 @@ interface LessonFinishProps {
   rightAnswered: number;
   items: LessonItem[] | undefined;
   onFinishLesson: () => void;
+  isAuthenticated: boolean;
 }
 
 export default function LessonFinish({
   rightAnswered,
   items,
   onFinishLesson,
+  isAuthenticated,
 }: LessonFinishProps) {
   const userAccuracy = items
     ? Math.round(
         (rightAnswered /
           items.filter((item) => item.type !== LessonItemType.SCENARIO_PROMPT)
             .length) *
-          1000
+          1000,
       ) / 10
     : 0;
 
@@ -47,8 +49,17 @@ export default function LessonFinish({
           <p>Accuracy</p>
         </CircularProgressbarWithChildren>
       </div>
-      <p>Thanks for trying the demo and I hope you enjoyed!</p>
-      <Link href="/">
+
+      {isAuthenticated ? (
+        <p>
+          Great job completing the lesson! Your progress has been saved, so you
+          can continue learning anytime. See you in the next lesson!
+        </p>
+      ) : (
+        <p>Thanks for trying the demo and I hope you enjoyed!</p>
+      )}
+
+      <Link href={isAuthenticated ? '/dashboard/learn' : '/'} className="w-max">
         <Button className="cursor-pointer" onClick={onFinishLesson}>
           Finish
         </Button>

--- a/src/lib/api/lesson.ts
+++ b/src/lib/api/lesson.ts
@@ -1,7 +1,13 @@
-import { Lesson } from '@/types/lessonType';
+import { Lesson, LessonSummary } from '@/types/lessonType';
 
 export async function fetchLesson(lessonUuid: string): Promise<Lesson> {
   const res = await fetch(`/api/lessons/${lessonUuid}`);
   if (!res.ok) throw new Error('Failed to fetch lesson');
+  return res.json();
+}
+
+export async function fetchLessons(): Promise<LessonSummary[]> {
+  const res = await fetch('/api/lessons');
+  if (!res.ok) throw new Error('Failed to fetch lessons');
   return res.json();
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function capitilizeFirstLetter(str: string) {
+  if (!str) return '';
+  return str
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/src/types/lessonType.ts
+++ b/src/types/lessonType.ts
@@ -42,3 +42,8 @@ export interface Lesson {
   title: string;
   items: LessonItem[];
 }
+
+export interface LessonSummary {
+  uuid: string;
+  title: string;
+}


### PR DESCRIPTION
## Description

Rendered lessons to the "Learn" page of the user dashboard. Cards are just mvp, will update later.

Had the "Lesson" page check if a user is logged in to determine what the `LessonFinish` page should display. The demo lesson and regular lessons have different `LessonFinish` messages.

## Screenshots

Demo:
<img width="439" height="340" alt="image" src="https://github.com/user-attachments/assets/7d9532e7-9c84-4b54-97c3-fd92734713a3" />

Regular lesson:
<img width="676" height="371" alt="image" src="https://github.com/user-attachments/assets/a84258ac-9051-4f2a-8b16-93040a87688f" />

Current Learn page on user dashboard
<img width="727" height="355" alt="image" src="https://github.com/user-attachments/assets/365cdec3-0678-4205-99af-e7b30d807274" />